### PR TITLE
Se modifican las clases para modo desktop, se separan los íconos con …

### DIFF
--- a/styles/css/vtex.flex-layout.css
+++ b/styles/css/vtex.flex-layout.css
@@ -2093,10 +2093,6 @@ height: 520px;
   max-width: none;
 }
 
-.flexRow--container-logoUSA {
-  align-items: center;
-  display: flex;
-}
 
 .flexRow--container-iconoes-header {
   align-items: center;
@@ -2193,22 +2189,6 @@ height: 520px;
   display: none;
 }
 
-.flexColChild--mnulogoUSA
-{
-  background-color: #dddddd !important;
-  width: 208px !important;
-  height: 40px !important;
-  margin-right: 35px;
-}
-.flexCol--mnulogoUSA
-{
-  width: 208px;
-  height: 40px;
-  margin-right: 35px;
-}
-
-
-
 
 @media (max-width:1024px)
 {
@@ -2238,34 +2218,6 @@ height: 520px;
       height: 20px;
       margin-right: 20px;
       margin-top: 10px;
-    }
-    /* ======== Menu mobile ============  */
-
-    .flexRow--icon-usa-login-mobile
-    {
-      border-bottom: 0.8px solid #3D3C3C;
-    }
-
-    .flexRowContent--icon-usa-login-mobile
-    {
-      justify-content: flex-start;
-      padding-left: 10px;
-      gap: 10px;
-    }
-
-
-      .flexColChild--mnulogoUSA
-    {
-      background-color: #524545 !important;
-      width: 150px;
-      height: 0px;
-      margin-right: 35px;
-    }
-    .flexCol--mnulogoUSA
-    {
-      height: 0px;
-      width: 160px;
-      margin-right: 35px;
     }
 
     :global(.vtex-store__template)
@@ -2789,7 +2741,7 @@ height: 520px;
       height: 57px;/*75px;*/
       background: #FFF;
       display: flex;
-      gap: 20px;
+      gap: 35px; /* ==============  Centrar logo CISA =====================================*/
       box-shadow: 0px 2px 15px 0px rgba(0, 0, 0, 0.12);
     }
 
@@ -3273,17 +3225,43 @@ height: 520px;
     .flexRowContent--category-menu-header-mobile-drawer {
       max-width: 56vw;
       margin: auto;
-  }
+    }
 
-  .flexColChild--mnulogoUSA
-  {
-    margin-top: -10px !important;
-    z-index: 999999 !important;
-    margin-right: 70px;
-    height: 140px;
-    border: 1px solid #0a0a0a;
-    border-radius: 15px;
-  }
+    /* ======== Menu mobile MEDIA ============  */
+
+    .flexRow--icon-usa-login-mobile
+    {
+      border-bottom: 0.8px solid #3D3C3C;
+    }
+
+    .flexRowContent--icon-usa-login-mobile
+    {
+      justify-content: flex-start;
+      padding-left: 10px;
+      gap: 10px;
+    }
+
+    /*
+    .flexCol--mnulogoUSA
+    {
+      height: 0px;
+      width: 150px;
+      margin-right: 35px;
+    }
+
+    .flexColChild--mnulogoUSA
+    {
+      width: 150px;
+      height: 140px;
+      margin-right: 35px;
+      margin-top: -30px !important;
+      margin-right: 70px;
+      z-index: 999999 !important;
+    }
+    */
+    .flexCol--col-mnu-USA       { width: 40px;  height: 10px;  margin-right: 80px;  margin-top: -110px;  }
+    .flexColChild--col-mnu-USA  { width: 40px;  height: 10px;  margin-right: -1px;   margin-top: -15px; }
+
 
 }
 
@@ -3341,7 +3319,7 @@ height: 520px;
   .flexRow--main-header-mobile :global(.vtex-store-components-3-x-logoImage) {
     height: 52px;
     width: 126px;
-    margin-left: 0px;
+    margin-left: 50px; /* =======================  Centrar Logo =======================*/
   }
 
   .flexRowContent--productDescription-row :global(.vtex-product-list-0-x-removeButton) {
@@ -3412,17 +3390,14 @@ height: 520px;
   }
 }
 
-/*=================  Bandera Idioma USA ====================*/
-.flexRow--col-mnu-USA
-{    border-bottom: 0.8px solid #3D3C3C;  }
-.flexRowContent--col-mnu-USA
-{    justify-content: flex-start;    padding-left: 10px;    gap: 10px;  }
+/*=================  Bandera Idioma USA Desktop ====================*/
+/*
+.flexRow--col-mnu-USA         { border-bottom: 0.8px solid #3D3C3C;  }
+.flexRowContent--col-mnu-USA  { justify-content: flex-start;    padding-left: 10px;    gap: 10px;  }
 
-.flexCol--col-mnu-USA
-{    height: 0px;    width: 160px;    margin-right: 125px;  margin-top: -50px;  }
-.flexColChild--col-mnu-USA
-{    width: 150px;    height: 0px;    margin-right: 35px;  }
-
+*/
+.flexCol--col-mnu-USA       { width: 140px;  height: 20px;  margin-right: 100px;  margin-top: -35px;  }
+.flexColChild--col-mnu-USA  { width: 140px;  height: 20px;  margin-left: -50px;  }
 
 /*=================  visualizador 3D ====================*/
 .flexRow--visualizador-contenedor

--- a/styles/css/vtex.menu.css
+++ b/styles/css/vtex.menu.css
@@ -84,6 +84,14 @@
   flex: 1;
 }
 
+/* ======== Bandera col Desktop ==========  */
+.styledLinkContent--bandera-col
+{
+  width: 75px !important;
+  height: 15px !important;
+  margin-right: -1px !important;
+  margin-top: 30px !important;
+}
 
 .menuItem--bandera-col--isClosed
 {
@@ -93,7 +101,7 @@
   background-image: url('assets/imgs/bandera_col_down.png');
   background-size: contain;
   background-repeat: no-repeat, repeat;
-  width: 65px;
+  width: 75px;
 }
 
 .menuItem--bandera-col--isOpen
@@ -103,7 +111,7 @@
   background-image: url('assets/imgs/bandera_col_up.png');
   background-size: contain;
   background-repeat: no-repeat, repeat;
-  width: 65px;
+  width: 75px;
 }
 
 
@@ -612,7 +620,7 @@ align-items: center;
     color: #3D3C3C !important;
 }
 
-
+/* ======== Bandera col MEDIA ==========  */
 .styledLinkContent--bandera-col
 {
   width: 20px !important;
@@ -623,25 +631,18 @@ align-items: center;
 
 .menuItem--bandera-col--isClosed
 {
-  margin-right: -25px;
-  margin-top: 8px;
-  margin-bottom: -30px;
-
-  background-image: url('assets/imgs/bandera_col_down.png');
-  background-size: contain;
-  background-repeat: no-repeat, repeat;
-  width: 50px;
+  margin-right: -25px !important;
+  margin-top: 8px !important;
+  margin-bottom: -30px !important;
+  width: 50px !important;
 }
 
 .menuItem--bandera-col--isOpen
 {
-  margin-right: -25px;
-  margin-top: 8px;
-  margin-bottom: -30px;
-  background-image: url('assets/imgs/bandera_col_up.png');
-  background-size: contain;
-  background-repeat: no-repeat, repeat;
-  width: 50px;
+  margin-right: -25px !important;
+  margin-top: 8px !important;
+  margin-bottom: -30px !important;
+  width: 50px !important;
 }
 
 

--- a/styles/css/vtex.store-components.css
+++ b/styles/css/vtex.store-components.css
@@ -954,19 +954,6 @@ width: 100%;
 }
 
 
-.flexRow--container-row-USA
-{    margin-top: 100px;  }
-.flexRowContent--container-row-USA
-{    justify-content: flex-start;    padding-left: 10px;    gap: 10px;  }
-
-.flexCol--col-mnu-USA
-{    height: 0px;    width: 160px;    margin-right: 35px;  }
-.flexColChild--col-mnu-USA
-{    background-color: #524545 !important;    width: 150px;    height: 0px;    margin-right: 35px;  }
-
-
-
-
 @media (min-width: 768px) and (max-width: 1024px) {
 
   /* .bannerPDPDesktop{
@@ -1023,6 +1010,8 @@ width: 100%;
     /*margin-right: 150px !important;*/
     /*margin-bottom: 150px;
     margin-top: -10px;*/
+
+    width: 110px;
     border: 1px solid  #a0a0a0;
     box-shadow: 0px 2px 2px 1px rgba(50,50,50,0.245);
     position:fixed;


### PR DESCRIPTION
Se modifican las hojas de estilo, para refinar la visualización en desktop, se modifica el tamaño del gap en  
css\vtex.flex-layout.css Línea 2728, para dar mas espacio entre los íconos de tal forma que se pueda centrar el logo de mejor forma, 
tambien se hace un margin-left: 50px; en la L3322 para que el menu oculto quede a la izq de la interface.