### PR TITLE
Se agregan reglas CSS para el menu y el slide

### DIFF
--- a/store/blocks/forms/pqrs.jsonc
+++ b/store/blocks/forms/pqrs.jsonc
@@ -183,6 +183,7 @@
     "children": [
       "form-input.text#nameAndLastname-formulario-pqrs",
       "form-input.text#cellPhone-formulario-pqrs",
+      "form-input.text#mail-formulario-pqrs",
       "form-input.text#addres-formulario-pqrs",
       "form-input.text#shoppingCity-formulario-pqrs"
     ],
@@ -209,6 +210,13 @@
       "placeholder": "Celular"
     }
   },
+  "form-input.text#mail-formulario-pqrs": {
+    "props": {
+      "pointer": "#/properties/email",
+      "placeholder": "Correo electrónico"
+    }
+  },
+
   "form-input.text#addres-formulario-pqrs": {
     "props": {
       "pointer": "#/properties/address",

--- a/styles/css/ceramicaitalia.menu-items-custom.css
+++ b/styles/css/ceramicaitalia.menu-items-custom.css
@@ -40,13 +40,38 @@
     display: none;
   }
 
+  /* ========  Original  igarcia =========================================================
   .MenuCustomContentList--show {
     display: block;
     max-height: max-content;
     z-index: 1;
   }
+    */
 
+  .MenuCustomContentList--show {
+    display: none !important;
+    opacity: 0;
+    visibility: hidden;
+    transition: all 0.2s ease;
+  }
 
+  /* 2. Solo lo mostramos cuando el mouse está REALMENTE sobre el contenedor padre */
+  .MenuCustom:hover .MenuCustomContentList--show {
+    display: block !important;
+    opacity: 1;
+    visibility: visible;
+  }
+  /* 3. Opcional: Si quieres que los submenús laterales también funcionen bien al salir el mouse */
+  .ceramicaitalia-menu-items-custom-0-x-MenuCustomListLi:hover .ceramicaitalia-menu-items-custom-0-x-MenuCustomContentSubList {
+    display: block !important;
+    opacity: 1;
+    visibility: visible;
+  }
+
+  .ceramicaitalia-menu-items-custom-0-x-MenuCustomListLi:not(:hover) .ceramicaitalia-menu-items-custom-0-x-MenuCustomContentSubList {
+    display: none !important;
+  }
+ /* ========  Fin de codigo nuevo 2026.03.09  ========================================================= */
 
   .MenuCustomContentList::-webkit-scrollbar {
     -webkit-appearance: none;

--- a/styles/css/vtex.menu.css
+++ b/styles/css/vtex.menu.css
@@ -435,6 +435,8 @@
 }
 
 
+
+
 @media (max-width: 1024px)
 {
 

--- a/styles/css/vtex.shelf.css
+++ b/styles/css/vtex.shelf.css
@@ -1,0 +1,16 @@
+.general  {
+  justify-content: center;
+  align-items: center;
+  gap: 40px;
+}
+
+.slide
+{
+  padding-left: 20px;
+  padding-right: 20px;
+  margin-left: 5px;
+  margin-right: 5px;
+  border-radius: 10px;
+  border: 1px solid #f8f8f8;
+  box-shadow: 0px 1px 4px #dbdbdb;
+}

--- a/styles/css/vtex.slider-layout.css
+++ b/styles/css/vtex.slider-layout.css
@@ -8,6 +8,7 @@
   min-height: 450px;
   margin: 0 auto;
   margin-top: -1px;
+  gap:10px;
 }
 
 .sliderTrackContainer {
@@ -20,6 +21,7 @@
   padding-top: 15px;
   padding-bottom: 57px;
   width: 101% !important;
+
 }
 
 .sliderTrackContainer--shelf-general{
@@ -30,8 +32,6 @@
   padding-top: 15px;
   padding-bottom: 50px;
 }
-
-
 
 .slideChildrenContainer--shelf-cocinas :global(.vtex-store-components-3-x-discountInsideContainer) {
   position: absolute;
@@ -86,6 +86,7 @@
   height: 8px !important;
   width: 8px !important;
   background-color: #F4F2F2;
+  gap:10px;
 }
 
 .paginationDot--carousel--isActive {
@@ -138,6 +139,8 @@
   padding-right: .5rem;
   min-height: 550px;
 }
+
+
 
 .sliderLayoutContainer--shelf-cocinas {
   padding-left: 8px!important;
@@ -1298,6 +1301,7 @@ text-transform: capitalize;
   }
   .slide--shelf-general :global(.vtex-add-to-cart-button-0-x-buttonText){
     font-size: 13px;
+    gap:10px;
   }
   .slide--shelf-destacados :global(.vtex-add-to-cart-button-0-x-buttonText) {
     font-size: 11px;


### PR DESCRIPTION
* Se arregla el modo de visualizar el slide en el bloque de "También compraron", debajo de las especificaciones de los productos.
* Se Generan reglas CSS para que cuando el menu principal pierda el foco se oculte automaticamente.
*